### PR TITLE
feat(examples): add HttpRateLimitError handling to demo files

### DIFF
--- a/examples/bitbank/demo.py
+++ b/examples/bitbank/demo.py
@@ -130,7 +130,8 @@ async def main() -> None:
             await demo_depth(adapter, pair)
     except HttpRateLimitError as e:
         retry_msg = f" Retry after {e.retry_after}s." if e.retry_after else ""
-        print(f"\nError: Rate limited.{retry_msg}")
+        url_msg = f" (URL: {e.url})" if e.url else ""
+        print(f"\nError: Rate limited.{retry_msg}{url_msg}")
         sys.exit(1)
     except HttpStatusError as e:
         print(f"\nError: HTTP {e.status_code} - {e.message}")

--- a/examples/stockanalysis/demo.py
+++ b/examples/stockanalysis/demo.py
@@ -82,7 +82,8 @@ async def main() -> None:
             await demo_ohlcv(adapter, symbol)
     except HttpRateLimitError as e:
         retry_msg = f" Retry after {e.retry_after}s." if e.retry_after else ""
-        print(f"\nError: Rate limited.{retry_msg}")
+        url_msg = f" (URL: {e.url})" if e.url else ""
+        print(f"\nError: Rate limited.{retry_msg}{url_msg}")
         sys.exit(1)
     except HttpStatusError as e:
         if e.status_code == 404:

--- a/examples/stooq/demo.py
+++ b/examples/stooq/demo.py
@@ -80,7 +80,8 @@ async def main() -> None:
             await demo_ohlcv(adapter, symbol)
     except HttpRateLimitError as e:
         retry_msg = f" Retry after {e.retry_after}s." if e.retry_after else ""
-        print(f"\nError: Rate limited.{retry_msg}")
+        url_msg = f" (URL: {e.url})" if e.url else ""
+        print(f"\nError: Rate limited.{retry_msg}{url_msg}")
         sys.exit(1)
     except HttpStatusError as e:
         if e.status_code == 404:


### PR DESCRIPTION
## Summary

- 3つのデモファイル（bitbank, stooq, stockanalysis）に `HttpRateLimitError` の明示的なハンドリングを追加
- レート制限時に `retry_after` 情報が利用可能な場合は表示
- `HttpRateLimitError` は `HttpStatusError` のサブクラスのため、先にキャッチするよう配置

## Test plan

- [x] `uv run ruff check examples/` - パス
- [x] `uv run ruff format --check examples/` - パス
- [x] `uv run mypy examples/` - パス
- [x] `uv run python -m examples.bitbank.demo` - 正常動作確認
- [x] `uv run python -m examples.stooq.demo` - 正常動作確認
- [x] `uv run python -m examples.stockanalysis.demo` - 正常動作確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)