### PR TITLE
test(rust): add compile-fail tests for type safety verification (US3)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,3 +18,4 @@ chrono = { version = "0.4", features = ["serde"] }
 regress = "0.10"
 
 [dev-dependencies]
+trybuild = "1.0"

--- a/rust/tests/compile_fail.rs
+++ b/rust/tests/compile_fail.rs
@@ -1,0 +1,10 @@
+//! Compile-fail tests to verify type safety constraints.
+//!
+//! These tests use trybuild to verify that certain code patterns
+//! fail to compile, documenting type safety guarantees as "living documentation".
+
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/rust/tests/ui/currency_no_from_string.rs
+++ b/rust/tests/ui/currency_no_from_string.rs
@@ -1,0 +1,12 @@
+//! Verify that Currency does not implement From<String>.
+//!
+//! Currency requires pattern validation (ISO 4217: ^[A-Z]{3}$),
+//! so only TryFrom<String> is provided, not From<String>.
+//! Using .into() should fail to compile.
+
+use marketschema::types::definitions::Currency;
+
+fn main() {
+    // This should fail: Currency only implements TryFrom, not From
+    let _currency: Currency = "JPY".to_string().into();
+}

--- a/rust/tests/ui/currency_no_from_string.stderr
+++ b/rust/tests/ui/currency_no_from_string.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `marketschema::types::Currency: From<String>` is not satisfied
+  --> tests/ui/currency_no_from_string.rs:11:49
+   |
+11 |     let _currency: Currency = "JPY".to_string().into();
+   |                                                 ^^^^ the trait `From<String>` is not implemented for `marketschema::types::Currency`
+   |
+   = help: the trait `From<String>` is not implemented for `marketschema::types::Currency`
+           but trait `From<&marketschema::types::Currency>` is implemented for it
+   = help: for that trait implementation, expected `&marketschema::types::Currency`, found `String`
+   = note: required for `String` to implement `Into<marketschema::types::Currency>`

--- a/rust/tests/ui/price_size_not_interchangeable.rs
+++ b/rust/tests/ui/price_size_not_interchangeable.rs
@@ -1,0 +1,12 @@
+//! Verify that Price and Size types are not interchangeable.
+//!
+//! Both Price and Size wrap f64, but they represent different domain concepts
+//! (price vs quantity). Direct assignment between them should fail to compile.
+
+use marketschema::types::definitions::{Price, Size};
+
+fn main() {
+    let price = Price(100.0);
+    // This should fail: Price cannot be directly assigned to Size
+    let _size: Size = price;
+}

--- a/rust/tests/ui/price_size_not_interchangeable.stderr
+++ b/rust/tests/ui/price_size_not_interchangeable.stderr
@@ -1,0 +1,7 @@
+error[E0308]: mismatched types
+  --> tests/ui/price_size_not_interchangeable.rs:11:23
+   |
+11 |     let _size: Size = price;
+   |                ----   ^^^^^ expected `Size`, found `Price`
+   |                |
+   |                expected due to this


### PR DESCRIPTION
## Summary

- trybuild を使用した compile-fail テストを追加し、型安全性の制約を「生きたドキュメント」として文書化
- Price/Size の相互代入防止テスト: 両方とも f64 をラップしているが直接代入できないことを検証
- Currency の `From<String>` 未実装確認テスト: パターン検証が必要なため `TryFrom` のみ提供されていることを検証

## Test plan

- [x] `cargo check` エラー 0 件 (T039)
- [x] `cargo clippy` 警告 0 件 (T040)
- [x] `cargo test compile_fail_tests` PASS (T041)
- [x] `cargo test` 全テスト PASS (64 tests)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)