### PR TITLE
feat(rust): implement AsyncHttpClient with builder pattern (US1)

### DIFF
--- a/crates/marketschema-http/Cargo.toml
+++ b/crates/marketschema-http/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 moka = { version = "0.12", features = ["future"] }
+tracing = "0.1"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/marketschema-http/src/error.rs
+++ b/crates/marketschema-http/src/error.rs
@@ -16,6 +16,11 @@
 use std::time::Duration;
 use thiserror::Error;
 
+use crate::{
+    HTTP_STATUS_BAD_GATEWAY, HTTP_STATUS_GATEWAY_TIMEOUT, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+    HTTP_STATUS_SERVICE_UNAVAILABLE,
+};
+
 /// HTTP error types.
 ///
 /// All errors include a message and optionally the URL that caused the error.
@@ -202,7 +207,14 @@ impl HttpError {
             Self::Timeout { .. } => true,
             Self::Connection { .. } => true,
             Self::Status { status_code, .. } => {
-                matches!(status_code, 500 | 502 | 503 | 504)
+                // Server errors are retryable
+                matches!(
+                    *status_code,
+                    HTTP_STATUS_INTERNAL_SERVER_ERROR
+                        | HTTP_STATUS_BAD_GATEWAY
+                        | HTTP_STATUS_SERVICE_UNAVAILABLE
+                        | HTTP_STATUS_GATEWAY_TIMEOUT
+                )
             }
             Self::RateLimit { .. } => true,
             _ => false,

--- a/crates/marketschema-http/src/lib.rs
+++ b/crates/marketschema-http/src/lib.rs
@@ -1,12 +1,12 @@
 //! Async HTTP client for marketschema adapters.
 //!
-//! This crate will provide a robust HTTP client layer for building market data adapters.
-//! Planned features include connection pooling, configurable timeouts, automatic retries,
-//! rate limiting, and response caching.
+//! This crate provides a robust HTTP client layer for building market data adapters.
+//! Features include connection pooling, configurable timeouts, and clean error handling.
+//! Planned features include automatic retries, rate limiting, and response caching.
 //!
-//! # Example (available after US1 implementation)
+//! # Example
 //!
-//! ```ignore
+//! ```rust,no_run
 //! use marketschema_http::{AsyncHttpClient, AsyncHttpClientBuilder};
 //! use std::time::Duration;
 //!
@@ -48,6 +48,26 @@ pub const DEFAULT_CACHE_TTL_SECS: u64 = 300;
 /// Default maximum cache size (number of entries).
 /// Note: Uses `u64` for moka Cache API compatibility (max_capacity parameter).
 pub const DEFAULT_CACHE_SIZE: u64 = 1000;
+
+// =============================================================================
+// HTTP Status Codes
+// Named constants to avoid magic numbers (CLAUDE.md: ハードコード禁止)
+// =============================================================================
+
+/// HTTP 429 Too Many Requests - Rate limit exceeded.
+pub const HTTP_STATUS_TOO_MANY_REQUESTS: u16 = 429;
+
+/// HTTP 500 Internal Server Error.
+pub const HTTP_STATUS_INTERNAL_SERVER_ERROR: u16 = 500;
+
+/// HTTP 502 Bad Gateway.
+pub const HTTP_STATUS_BAD_GATEWAY: u16 = 502;
+
+/// HTTP 503 Service Unavailable.
+pub const HTTP_STATUS_SERVICE_UNAVAILABLE: u16 = 503;
+
+/// HTTP 504 Gateway Timeout.
+pub const HTTP_STATUS_GATEWAY_TIMEOUT: u16 = 504;
 
 // =============================================================================
 // Modules


### PR DESCRIPTION
## Summary
- Add `AsyncHttpClient` struct for executing async GET requests with support for raw response, JSON, and text parsing
- Implement `AsyncHttpClientBuilder` with fluent API for configuring timeout, max connections, and default headers
- Create comprehensive `HttpError` enum with variants for timeout, connection, status (4xx/5xx), rate limit (429), parse errors, and build errors
- Add helper methods `url()`, `status_code()`, and `is_retryable()` for error handling
- Include compile-time verification that `AsyncHttpClient` is `Send + Sync`
- Add extensive test suite with wiremock for mocking HTTP responses

## Test plan
- [ ] Run `cargo test -p marketschema-http` to verify all tests pass
- [ ] Run `cargo clippy -p marketschema-http` to check for lints
- [ ] Run `cargo doc -p marketschema-http` to verify documentation builds
- [ ] Verify integration tests with wiremock cover success and error scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)