### PR TITLE
feat(rust): add Retry-After header parsing for HTTP 429 responses (US2)

### DIFF
--- a/crates/marketschema-http/src/client.rs
+++ b/crates/marketschema-http/src/client.rs
@@ -316,7 +316,7 @@ impl AsyncHttpClient {
         let status_code = status.as_u16();
 
         // Parse Retry-After header before consuming response body
-        // FR-R014: HTTP 429 ステータス時は retry_after フィールドを持つ
+        // FR-R014: HTTP 429 ステータス時は HttpError::RateLimit を返す（retry_after はヘッダーから取得）
         let retry_after = if status_code == HTTP_STATUS_TOO_MANY_REQUESTS {
             Self::parse_retry_after_header(&response)
         } else {
@@ -371,17 +371,32 @@ impl AsyncHttpClient {
     /// HTTP-date format is complex and rarely used; we return None for it.
     fn parse_retry_after_header(response: &Response) -> Option<Duration> {
         let header_value = response.headers().get("retry-after")?;
-        let header_str = header_value.to_str().ok()?;
+
+        // Explicitly handle non-ASCII header values instead of using .ok()?
+        // (CLAUDE.md: 暗黙的フォールバック禁止)
+        let header_str = match header_value.to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    header_value = ?header_value,
+                    "Retry-After header contains non-ASCII characters, ignoring"
+                );
+                return None;
+            }
+        };
 
         // Try to parse as seconds (integer format)
+        // RFC 7231: Retry-After can be either delta-seconds or HTTP-date
+        // We only support delta-seconds; HTTP-date format is complex and rarely used
         match header_str.trim().parse::<u64>() {
             Ok(seconds) => Some(Duration::from_secs(seconds)),
-            Err(_) => {
-                // Could be HTTP-date format; log and return None
-                // HTTP-date parsing is complex and rarely needed
-                tracing::debug!(
+            Err(parse_err) => {
+                // Could be HTTP-date format, negative value, overflow, or other invalid input
+                tracing::warn!(
                     retry_after = %header_str,
-                    "Retry-After header is not in seconds format, ignoring"
+                    error = %parse_err,
+                    "Retry-After header is not a valid positive integer, ignoring (may be HTTP-date format)"
                 );
                 None
             }


### PR DESCRIPTION
## Summary
- Implement FR-R014: parse Retry-After header when receiving HTTP 429 Too Many Requests status
- Add `parse_retry_after_header()` method to `AsyncHttpClient` supporting integer seconds format
- Gracefully handle HTTP-date format with debug logging (returns None)
- Add comprehensive tests for Retry-After parsing scenarios

## Test plan
- [x] Unit tests for integer seconds format parsing
- [x] Unit tests for HTTP-date format handling (graceful fallback)
- [x] Unit tests for missing header case
- [x] Integration with HTTP 429 error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)