### PR TITLE
test(rust): add comprehensive BaseAdapter trait tests

### DIFF
--- a/crates/marketschema-adapters/Cargo.toml
+++ b/crates/marketschema-adapters/Cargo.toml
@@ -25,4 +25,5 @@ serde_json = "1.0"
 thiserror = "2.0"
 
 [dev-dependencies]
+marketschema-adapters = { path = ".", features = ["test-utils"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
## Summary
- Add `adapter_test.rs` with comprehensive tests for `BaseAdapter` trait implementation
- Cover all trait functionality: `source_name()`, default mapping methods
- Verify `Send + Sync` trait bounds for thread safety
- Test `AdapterRegistry` integration (register, get, list, is_registered)
- Include thread safety tests with concurrent adapter access

## Test plan
- [x] All existing tests continue to pass
- [x] New tests cover BaseAdapter trait basic functionality
- [x] New tests verify mapping transformations work correctly
- [x] New tests validate AdapterRegistry operations
- [x] Thread safety is verified with concurrent access tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)