### PR TITLE
fix(hookify): extend implicit fallback detection to else clauses

### DIFF
--- a/.claude/hookify.implicit-fallback-python.local.md
+++ b/.claude/hookify.implicit-fallback-python.local.md
@@ -8,7 +8,7 @@ conditions:
     pattern: \.py$
   - field: content
     operator: regex_match
-    pattern: except.*:\s*(return|pass|continue|\.{3})|else:\s*(return\s+["'\d\[\{]|return\s+None|\w+\s*=\s*["'\d\[\{]|\w+\s*=\s*None)
+    pattern: except.*:\s*(return|pass|continue|\.{3})|(?:^|\s)else:\s*(return\s+[-"'\d\[\{(]|return\s+(None|True|False)\b|\w+\s*=\s*[-"'\d\[\{(]|\w+\s*=\s*(None|True|False)\b)
 ---
 
 ## CLAUDE.md 違反: 暗黙的フォールバック検出
@@ -26,6 +26,9 @@ conditions:
 | `except: continue` | ループ内で例外を無視して続行 |
 | `except: ...` | 例外を握りつぶす省略記法 |
 | `else: return "..."` | ⚠️ 要確認: else でハードコードされた値を返していないか |
+| `else: return -1` | ⚠️ 要確認: else で負の数を返していないか |
+| `else: return True/False` | ⚠️ 要確認: else でブール値を返していないか |
+| `else: return (...)` | ⚠️ 要確認: else でタプルを返していないか |
 | `else: x = "..."` | ⚠️ 要確認: else でハードコードされた値を代入していないか |
 
 ### CLAUDE.md の規定
@@ -98,5 +101,10 @@ else:
 - テストコード内での意図的なエラー無視
 - クリーンアップ処理での例外無視（要コメント）
 - 明示的な型指定がある `except SpecificError` の場合
+- **`try-except-else` 構文での else ブロック**（例外が発生しなかった場合の正常処理）
+- **`for-else` / `while-else` 構文**（break なしでループが完了した場合の処理）
+- **f-string**: 動的な値を含む可能性があるため検出対象外
+
+**注意**: このルールは CLAUDE.md の「暗黙的フォールバック禁止」と「ハードコード禁止」の両方に関連します。else 節でのハードコード値は主に「ハードコード禁止」ルールに該当しますが、エラー処理の文脈では「暗黙的フォールバック」の可能性も考慮してください。
 
 この警告が誤検知の場合は、コメントでその理由を説明してください。


### PR DESCRIPTION
## Summary
- Extended the implicit fallback detection rule to catch hardcoded values in else clauses
- Added regex pattern to detect `else: return "..."` and `else: x = "..."` patterns
- Added documentation with examples for the new detection patterns

## Test plan
- [ ] Verify the regex pattern correctly matches else clauses with hardcoded returns
- [ ] Verify the regex pattern correctly matches else clauses with hardcoded assignments
- [ ] Confirm false positives are minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)